### PR TITLE
feat: Web UI Phase 2 - 検索・フィルタとチャート

### DIFF
--- a/web/templates/history.html
+++ b/web/templates/history.html
@@ -4,6 +4,49 @@
 
 {{define "content"}}
 <div class="px-4 py-6 sm:px-0">
+    <!-- 検索・フィルタ -->
+    <div class="bg-white shadow rounded-lg mb-6">
+        <div class="px-4 py-5 sm:p-6">
+            <form method="GET" action="/history" class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
+                <div>
+                    <label for="search" class="block text-sm font-medium text-gray-700">キーワード検索</label>
+                    <input type="text" name="search" id="search" value="{{.Search}}" placeholder="URL・タイトル"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm border px-3 py-2">
+                </div>
+                <div>
+                    <label for="domain" class="block text-sm font-medium text-gray-700">ドメイン</label>
+                    <select name="domain" id="domain"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm border px-3 py-2">
+                        <option value="">すべて</option>
+                        {{range .Domains}}
+                        <option value="{{.}}" {{if eq . $.Domain}}selected{{end}}>{{.}}</option>
+                        {{end}}
+                    </select>
+                </div>
+                <div>
+                    <label for="from" class="block text-sm font-medium text-gray-700">開始日</label>
+                    <input type="date" name="from" id="from" value="{{.From}}"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm border px-3 py-2">
+                </div>
+                <div>
+                    <label for="to" class="block text-sm font-medium text-gray-700">終了日</label>
+                    <input type="date" name="to" id="to" value="{{.To}}"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm border px-3 py-2">
+                </div>
+                <div class="flex items-end gap-2">
+                    <button type="submit"
+                        class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                        検索
+                    </button>
+                    <a href="/history"
+                        class="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                        クリア
+                    </a>
+                </div>
+            </form>
+        </div>
+    </div>
+
     <div class="bg-white shadow rounded-lg">
         <div class="px-4 py-5 sm:p-6">
             <div class="flex justify-between items-center mb-4">
@@ -32,7 +75,7 @@
                     </thead>
                     <tbody class="bg-white divide-y divide-gray-200">
                         {{range .Visits}}
-                        <tr class="hover:bg-gray-50">
+                        <tr class="hover:bg-gray-50 cursor-pointer" onclick="showDetail('{{.Title}}', '{{.URL}}', '{{.Domain}}', '{{formatTime .VisitTime}}')">
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                                 {{formatTime .VisitTime}}
                             </td>
@@ -45,9 +88,9 @@
                                 {{.Domain}}
                             </td>
                             <td class="px-6 py-4 text-sm text-gray-500">
-                                <a href="{{.URL}}" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-800 max-w-xs truncate block" title="{{.URL}}">
+                                <span class="text-blue-600 max-w-xs truncate block" title="{{.URL}}">
                                     {{truncate .URL 50}}
-                                </a>
+                                </span>
                             </td>
                         </tr>
                         {{else}}
@@ -65,12 +108,12 @@
             <div class="mt-6 flex items-center justify-between border-t border-gray-200 pt-4">
                 <div class="flex-1 flex justify-between sm:hidden">
                     {{if .HasPrev}}
-                    <a href="/history?page={{.PrevPage}}" class="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
+                    <a href="/history?page={{.PrevPage}}{{if .Search}}&search={{.Search}}{{end}}{{if .Domain}}&domain={{.Domain}}{{end}}{{if .From}}&from={{.From}}{{end}}{{if .To}}&to={{.To}}{{end}}" class="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
                         前へ
                     </a>
                     {{end}}
                     {{if .HasNext}}
-                    <a href="/history?page={{.NextPage}}" class="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
+                    <a href="/history?page={{.NextPage}}{{if .Search}}&search={{.Search}}{{end}}{{if .Domain}}&domain={{.Domain}}{{end}}{{if .From}}&from={{.From}}{{end}}{{if .To}}&to={{.To}}{{end}}" class="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
                         次へ
                     </a>
                     {{end}}
@@ -84,7 +127,7 @@
                     <div>
                         <nav class="relative z-0 inline-flex rounded-md shadow-sm -space-x-px" aria-label="Pagination">
                             {{if .HasPrev}}
-                            <a href="/history?page={{.PrevPage}}" class="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50">
+                            <a href="/history?page={{.PrevPage}}{{if .Search}}&search={{.Search}}{{end}}{{if .Domain}}&domain={{.Domain}}{{end}}{{if .From}}&from={{.From}}{{end}}{{if .To}}&to={{.To}}{{end}}" class="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50">
                                 <span class="sr-only">前へ</span>
                                 <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                                     <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
@@ -104,7 +147,7 @@
                             </span>
 
                             {{if .HasNext}}
-                            <a href="/history?page={{.NextPage}}" class="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50">
+                            <a href="/history?page={{.NextPage}}{{if .Search}}&search={{.Search}}{{end}}{{if .Domain}}&domain={{.Domain}}{{end}}{{if .From}}&from={{.From}}{{end}}{{if .To}}&to={{.To}}{{end}}" class="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50">
                                 <span class="sr-only">次へ</span>
                                 <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                                     <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
@@ -125,4 +168,64 @@
         </div>
     </div>
 </div>
+
+<!-- 詳細モーダル -->
+<div id="detailModal" class="fixed inset-0 bg-gray-600 bg-opacity-50 hidden overflow-y-auto h-full w-full z-50" onclick="hideDetail()">
+    <div class="relative top-20 mx-auto p-5 border w-11/12 max-w-2xl shadow-lg rounded-md bg-white" onclick="event.stopPropagation()">
+        <div class="mt-3">
+            <div class="flex justify-between items-start mb-4">
+                <h3 class="text-lg font-medium text-gray-900" id="modalTitle">タイトル</h3>
+                <button onclick="hideDetail()" class="text-gray-400 hover:text-gray-600">
+                    <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                    </svg>
+                </button>
+            </div>
+            <div class="space-y-4">
+                <div>
+                    <label class="block text-sm font-medium text-gray-500">ドメイン</label>
+                    <p class="mt-1 text-sm text-gray-900" id="modalDomain"></p>
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-500">訪問日時</label>
+                    <p class="mt-1 text-sm text-gray-900" id="modalTime"></p>
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-500">URL</label>
+                    <p class="mt-1 text-sm text-gray-900 break-all" id="modalURL"></p>
+                </div>
+                <div class="pt-4">
+                    <a id="modalLink" href="#" target="_blank" rel="noopener noreferrer"
+                        class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700">
+                        URLを開く
+                        <svg class="ml-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+function showDetail(title, url, domain, time) {
+    document.getElementById('modalTitle').textContent = title || '(タイトルなし)';
+    document.getElementById('modalURL').textContent = url;
+    document.getElementById('modalDomain').textContent = domain;
+    document.getElementById('modalTime').textContent = time;
+    document.getElementById('modalLink').href = url;
+    document.getElementById('detailModal').classList.remove('hidden');
+}
+
+function hideDetail() {
+    document.getElementById('detailModal').classList.add('hidden');
+}
+
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+        hideDetail();
+    }
+});
+</script>
 {{end}}

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -27,6 +27,9 @@
                         <a href="/history" class="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">
                             履歴一覧
                         </a>
+                        <a href="/stats" class="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">
+                            統計
+                        </a>
                     </div>
                 </div>
             </div>

--- a/web/templates/stats.html
+++ b/web/templates/stats.html
@@ -1,0 +1,133 @@
+{{template "layout" .}}
+
+{{define "title"}}統計 - Safari履歴分析{{end}}
+
+{{define "content"}}
+<div class="px-4 py-6 sm:px-0">
+    <!-- フィルタ -->
+    <div class="bg-white shadow rounded-lg mb-6">
+        <div class="px-4 py-5 sm:p-6">
+            <form method="GET" action="/stats" class="flex flex-wrap gap-4 items-end">
+                <div>
+                    <label for="domain" class="block text-sm font-medium text-gray-700">ドメイン</label>
+                    <select name="domain" id="domain"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm border px-3 py-2">
+                        <option value="">すべて</option>
+                        {{range .Domains}}
+                        <option value="{{.}}" {{if eq . $.Domain}}selected{{end}}>{{.}}</option>
+                        {{end}}
+                    </select>
+                </div>
+                <div>
+                    <label for="days" class="block text-sm font-medium text-gray-700">日数</label>
+                    <select name="days" id="days"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm border px-3 py-2">
+                        <option value="7" {{if eq .Days 7}}selected{{end}}>7日</option>
+                        <option value="14" {{if eq .Days 14}}selected{{end}}>14日</option>
+                        <option value="30" {{if eq .Days 30}}selected{{end}}>30日</option>
+                        <option value="90" {{if eq .Days 90}}selected{{end}}>90日</option>
+                    </select>
+                </div>
+                <button type="submit"
+                    class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700">
+                    適用
+                </button>
+                <a href="/stats"
+                    class="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
+                    クリア
+                </a>
+            </form>
+        </div>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <!-- 時間帯別統計 -->
+        <div class="bg-white shadow rounded-lg">
+            <div class="px-4 py-5 sm:p-6">
+                <h3 class="text-lg leading-6 font-medium text-gray-900 mb-4">時間帯別訪問数</h3>
+                <div class="space-y-2">
+                    {{$maxHourly := 0}}
+                    {{range .HourlyStats}}
+                        {{if gt .VisitCount $maxHourly}}
+                            {{$maxHourly = .VisitCount}}
+                        {{end}}
+                    {{end}}
+                    {{range .HourlyStats}}
+                    <div class="flex items-center">
+                        <div class="w-12 text-sm text-gray-600">{{printf "%02d" .Hour}}:00</div>
+                        <div class="flex-1 mx-2">
+                            <div class="bg-gray-200 rounded-full h-5">
+                                {{if gt $maxHourly 0}}
+                                <div class="bg-green-500 rounded-full h-5" style="width: {{percentage .VisitCount $maxHourly}}%"></div>
+                                {{end}}
+                            </div>
+                        </div>
+                        <div class="w-12 text-right text-sm text-gray-600">{{.VisitCount}}</div>
+                    </div>
+                    {{end}}
+                </div>
+            </div>
+        </div>
+
+        <!-- 日別統計 -->
+        <div class="bg-white shadow rounded-lg">
+            <div class="px-4 py-5 sm:p-6">
+                <h3 class="text-lg leading-6 font-medium text-gray-900 mb-4">日別訪問数（過去{{.Days}}日間）</h3>
+                {{if .DailyStats}}
+                <div class="space-y-2">
+                    {{$maxDaily := 0}}
+                    {{range .DailyStats}}
+                        {{if gt .VisitCount $maxDaily}}
+                            {{$maxDaily = .VisitCount}}
+                        {{end}}
+                    {{end}}
+                    {{range .DailyStats}}
+                    <div class="flex items-center">
+                        <div class="w-24 text-sm text-gray-600">{{.Date}}</div>
+                        <div class="flex-1 mx-2">
+                            <div class="bg-gray-200 rounded-full h-5">
+                                {{if gt $maxDaily 0}}
+                                <div class="bg-blue-500 rounded-full h-5" style="width: {{percentage .VisitCount $maxDaily}}%"></div>
+                                {{end}}
+                            </div>
+                        </div>
+                        <div class="w-12 text-right text-sm text-gray-600">{{.VisitCount}}</div>
+                    </div>
+                    {{end}}
+                </div>
+                {{else}}
+                <p class="text-gray-500 text-sm">データがありません</p>
+                {{end}}
+            </div>
+        </div>
+
+        <!-- ドメイン別統計 -->
+        <div class="bg-white shadow rounded-lg lg:col-span-2">
+            <div class="px-4 py-5 sm:p-6">
+                <h3 class="text-lg leading-6 font-medium text-gray-900 mb-4">ドメイン別訪問数（Top 10）</h3>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    {{$maxDomain := 0}}
+                    {{range .DomainStats}}
+                        {{if gt .VisitCount $maxDomain}}
+                            {{$maxDomain = .VisitCount}}
+                        {{end}}
+                    {{end}}
+                    {{range .DomainStats}}
+                    <div class="flex items-center">
+                        <div class="w-32 truncate text-sm text-gray-600" title="{{.Domain}}">{{.Domain}}</div>
+                        <div class="flex-1 mx-2">
+                            <div class="bg-gray-200 rounded-full h-5">
+                                {{if gt $maxDomain 0}}
+                                <div class="bg-purple-500 rounded-full h-5" style="width: {{percentage .VisitCount $maxDomain}}%"></div>
+                                {{end}}
+                            </div>
+                        </div>
+                        <div class="w-16 text-right text-sm text-gray-600">{{.VisitCount}}</div>
+                    </div>
+                    {{end}}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{{end}}


### PR DESCRIPTION
## Summary
- 履歴一覧に検索・フィルタ機能を追加
- 履歴詳細モーダルを追加
- 統計ページを追加（時間帯別・日別・ドメイン別チャート）
- APIエンドポイントを拡張

## 新機能

### 検索・フィルタ
- キーワード検索（URL・タイトル）
- ドメインフィルタ（ドロップダウン）
- 日付範囲フィルタ（日付ピッカー）
- フィルタ条件をページネーションに引き継ぎ

### 履歴詳細モーダル
- 履歴行をクリックで詳細表示
- タイトル、URL、ドメイン、訪問日時を表示
- URLを新規タブで開くボタン
- Escキーで閉じる

### 統計ページ（/stats）
- 時間帯別訪問数（0-23時）
- 日別訪問数（過去7/14/30/90日）
- ドメイン別訪問数（Top 10）
- ドメインフィルタ対応

### 新規APIエンドポイント
- `GET /api/stats/hourly?domain=xxx` - 時間帯別統計
- `GET /api/stats/daily?days=30&domain=xxx` - 日別統計
- `GET /api/domains` - ドメイン一覧

Closes #21

## Test plan
- [x] `make quality` で全テストが通ることを確認
- [ ] 検索・フィルタの動作確認
- [ ] モーダル表示の動作確認
- [ ] 統計ページの表示確認
- [ ] APIエンドポイントのレスポンス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)