### PR TITLE
Makefileを最新のコードベースに対応

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: build run clean test fmt lint quality help
+.PHONY: build run clean test fmt lint quality help install uninstall serve interactive
 
 # バイナリ名
 BINARY := hist
+
+# インストール先
+PREFIX := /usr/local/bin
 
 # デフォルトターゲット
 all: build
@@ -14,13 +17,38 @@ build:
 run: build
 	./$(BINARY)
 
+# Webサーバーモードで実行
+serve: build
+	./$(BINARY) -serve
+
+# インタラクティブモードで実行
+interactive: build
+	./$(BINARY) -interactive
+
+# インストール
+install: build
+	cp $(BINARY) $(PREFIX)/$(BINARY)
+	@echo "$(BINARY) を $(PREFIX) にインストールしました"
+
+# アンインストール
+uninstall:
+	rm -f $(PREFIX)/$(BINARY)
+	@echo "$(BINARY) を $(PREFIX) から削除しました"
+
 # クリーンアップ
 clean:
 	rm -f $(BINARY)
+	go clean
 
 # テスト
 test:
 	go test -v ./...
+
+# テスト（カバレッジ付き）
+test-coverage:
+	go test -v -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out -o coverage.html
+	@echo "カバレッジレポートを coverage.html に出力しました"
 
 # フォーマット
 fmt:
@@ -33,14 +61,25 @@ lint:
 # 品質チェック（テスト + フォーマット + リント）
 quality: test fmt lint
 
+# 依存関係の更新
+deps:
+	go mod tidy
+	go mod download
+
 # ヘルプ
 help:
 	@echo "使用可能なターゲット:"
-	@echo "  build    - バイナリをビルド"
-	@echo "  run      - ビルドして実行"
-	@echo "  clean    - バイナリを削除"
-	@echo "  test     - テストを実行"
-	@echo "  fmt      - コードをフォーマット"
-	@echo "  lint     - リントを実行"
-	@echo "  quality  - テスト + フォーマット + リント"
-	@echo "  help     - このヘルプを表示"
+	@echo "  build         - バイナリをビルド"
+	@echo "  run           - ビルドして実行（CLI）"
+	@echo "  serve         - Webサーバーモードで実行"
+	@echo "  interactive   - インタラクティブモードで実行"
+	@echo "  install       - $(PREFIX) にインストール"
+	@echo "  uninstall     - $(PREFIX) から削除"
+	@echo "  clean         - バイナリを削除"
+	@echo "  test          - テストを実行"
+	@echo "  test-coverage - カバレッジ付きテスト"
+	@echo "  fmt           - コードをフォーマット"
+	@echo "  lint          - リントを実行"
+	@echo "  quality       - テスト + フォーマット + リント"
+	@echo "  deps          - 依存関係を更新"
+	@echo "  help          - このヘルプを表示"


### PR DESCRIPTION
## Summary
- Webサーバーモード、インタラクティブモードの実行ターゲットを追加
- インストール/アンインストールターゲットを追加
- カバレッジテストと依存関係更新ターゲットを追加

## 変更内容
- `serve`: Webサーバーモードで実行
- `interactive`: インタラクティブモードで実行
- `install`/`uninstall`: /usr/local/binへのインストール/アンインストール
- `test-coverage`: カバレッジレポート生成
- `deps`: 依存関係の更新
- `clean`に`go clean`を追加
- ヘルプメッセージを更新

## Test plan
- [ ] `make help` で新しいターゲットが表示されることを確認
- [ ] `make serve` でWebサーバーが起動することを確認
- [ ] `make interactive` でインタラクティブモードが起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)